### PR TITLE
Only test QP solvers that are enabled at build time

### DIFF
--- a/tests/TestQpSolversEnabled.cpp
+++ b/tests/TestQpSolversEnabled.cpp
@@ -17,40 +17,54 @@ TEST(TestQpSolversEnabled, Any)
   checkOneSolver(QpSolverType::Any);
 }
 
+#if ENABLE_QLD
 TEST(TestQpSolversEnabled, QLD)
 {
   checkOneSolver(QpSolverType::QLD);
 }
+#endif
 
+#if ENABLE_QUADPROG
 TEST(TestQpSolversEnabled, QuadProg)
 {
   checkOneSolver(QpSolverType::QuadProg);
 }
+#endif
 
+#if ENABLE_LSSOL
 TEST(TestQpSolversEnabled, LSSOL)
 {
   checkOneSolver(QpSolverType::LSSOL);
 }
+#endif
 
+#if ENABLE_JRLQP
 TEST(TestQpSolversEnabled, JRLQP)
 {
   checkOneSolver(QpSolverType::JRLQP);
 }
+#endif
 
+#if ENABLE_QPOASES
 TEST(TestQpSolversEnabled, qpOASES)
 {
   checkOneSolver(QpSolverType::qpOASES);
 }
+#endif
 
+#if ENABLE_OSQP
 TEST(TestQpSolversEnabled, OSQP)
 {
   checkOneSolver(QpSolverType::OSQP);
 }
+#endif
 
+#if ENABLE_NASOQ
 TEST(TestQpSolversEnabled, NASOQ)
 {
   checkOneSolver(QpSolverType::NASOQ);
 }
+#endif
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
While working on https://github.com/isri-aist/QpSolverCollection/issues/1, some tests were failing as I did not have all the dependencies enabled. Not sure if that was intended, if that was not intended this PR fixes the test failure if some dependencies are not enabled.