### PR TITLE
[CI] test with solvers installed from sources

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,15 +31,15 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04]
         build-type: [Debug, RelWithDebInfo]
-        standalone: [ON, OFF]
-        solvers-from-source: [ON, OFF]
+        standalone: [standalone, catkin]
+        solvers-from-source: [SolversFromSource, SolversFromAPT]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set environment variables
         run: |
           echo "LD_LIBRARY_PATH=/opt/blasfeo/lib:/opt/hpipm/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV # for HPIPM
       - name: Set ROS version
-        if: matrix.standalone == 'OFF'
+        if: matrix.standalone == 'catkin'
         run: |
           if [ "${{ matrix.os }}" == "ubuntu-20.04" ]
           then
@@ -64,7 +64,7 @@ jobs:
         env:
           GITLAB_TOKEN : ${{ secrets.GITLAB_TOKEN }}
       - name: Install ROS
-        if: matrix.standalone == 'OFF'
+        if: matrix.standalone == 'catkin'
         run: |
           set -e
           set -x
@@ -73,7 +73,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -qq ros-${ROS_DISTRO}-ros-base ${PYTHON_PACKAGE_PREFIX}-catkin-tools ${PYTHON_PACKAGE_PREFIX}-rosdep doxygen graphviz
       - name: Setup catkin workspace
-        if: matrix.standalone == 'OFF'
+        if: matrix.standalone == 'catkin'
         run: |
           set -e
           set -x
@@ -85,18 +85,18 @@ jobs:
           catkin init
           catkin build --limit-status-rate 0.1
       - name: Checkout repository code
-        if: matrix.standalone == 'OFF'
+        if: matrix.standalone == 'catkin'
         uses: actions/checkout@v3
         with:
           submodules: recursive
           path: catkin_ws/src/QpSolverCollection
       - name: Checkout repository code
-        if: matrix.standalone == 'ON'
+        if: matrix.standalone == 'standalone'
         uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Rosdep install
-        if: matrix.standalone == 'OFF'
+        if: matrix.standalone == 'catkin'
         run: |
           set -e
           set -x
@@ -108,7 +108,7 @@ jobs:
           rosdep update
           rosdep install -y -r --from-paths src --ignore-src
       - name: Install GTest
-        if: matrix.standalone == 'ON' && matrix.os == 'ubuntu-18.04'
+        if: matrix.standalone == 'standalone' && matrix.os == 'ubuntu-18.04'
         uses: jrl-umi3218/github-actions/install-dependencies@master
         with:
           build-type: ${{ matrix.build-type }}
@@ -116,7 +116,7 @@ jobs:
             - path: google/googletest
               ref: release-1.12.1
       - name: Install solvers via apt
-        if: matrix.solvers-from-source == 'OFF'
+        if: matrix.solvers-from-source == 'SolversFromAPT'
         uses: jrl-umi3218/github-actions/install-dependencies@master
         with:
           build-type: ${{ matrix.build-type }}
@@ -126,7 +126,7 @@ jobs:
                 cloudsmith: mc-rtc/head
             apt: libmetis-dev libeigen3-dev libgtest-dev graphviz doxygen libeigen-qld-dev libeigen-quadprog-dev libjrl-qp-dev libqpoases-dev libosqp-eigen-dev libnasoq-dev libhpipm-dev libproxsuite-dev libqpmad-dev
       - name: Install solvers from source
-        if: matrix.solvers-from-source == 'ON'
+        if: matrix.solvers-from-source == 'SolversFromSource'
         uses: jrl-umi3218/github-actions/install-dependencies@master
         with:
           build-type: ${{ matrix.build-type }}
@@ -163,7 +163,7 @@ jobs:
             - path: git@gite.lirmm.fr:multi-contact/eigen-lssol
               options: -DBUILD_TESTING=OFF -DPYTHON_BINDING=OFF -DINSTALL_DOCUMENTATION=OFF
       - name: Catkin build
-        if: matrix.standalone == 'OFF'
+        if: matrix.standalone == 'catkin'
         run: |
           set -e
           set -x
@@ -175,7 +175,7 @@ jobs:
           -DDEFAULT_ENABLE_ALL=ON -DENABLE_LSSOL=${{ env.ENABLE_PRIVATE_SOLVERS }} \
           -DSKIP_PRIVATE_SOLVER_TEST=${{ env.SKIP_PRIVATE_SOLVER_TEST }} -DFORCE_ALL_SOLVER_TEST=ON -DINSTALL_DOCUMENTATION=ON
       - name: Run tests
-        if: matrix.standalone == 'OFF'
+        if: matrix.standalone == 'catkin'
         run: |
           set -e
           set -x
@@ -186,14 +186,14 @@ jobs:
           catkin build --limit-status-rate 0.1 --catkin-make-args run_tests -- qp_solver_collection --no-deps
           catkin_test_results --verbose --all build
       - name: Build and test
-        if: matrix.standalone == 'ON'
+        if: matrix.standalone == 'standalone'
         uses: jrl-umi3218/github-actions/build-cmake-project@master
         with:
           build-type: ${{ matrix.build-type }}
           options: -DDEFAULT_ENABLE_ALL=ON -DENABLE_LSSOL=${{ env.ENABLE_PRIVATE_SOLVERS }} -DSKIP_PRIVATE_SOLVER_TEST=${{ env.SKIP_PRIVATE_SOLVER_TEST }} -DFORCE_ALL_SOLVER_TEST=ON -DINSTALL_DOCUMENTATION=ON
       - name: Upload documentation
         # Only run for one configuration and on origin master branch
-        if: matrix.os == 'ubuntu-20.04' && matrix.build-type == 'RelWithDebInfo' && matrix.standalone == 'OFF' && matrix.solvers-from-source == 'OFF' && github.repository_owner == 'isri-aist' && github.ref == 'refs/heads/master'
+        if: matrix.os == 'ubuntu-20.04' && matrix.build-type == 'RelWithDebInfo' && matrix.standalone == 'catkin' && matrix.solvers-from-source == 'SolversFromAPT' && github.repository_owner == 'isri-aist' && github.ref == 'refs/heads/master'
         run: |
           set -e
           set -x

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
         os: [ubuntu-20.04, ubuntu-18.04]
         build-type: [Debug, RelWithDebInfo]
         standalone: [ON, OFF]
+        solvers-from-source: [ON, OFF]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set environment variables
@@ -114,7 +115,8 @@ jobs:
           github: |
             - path: google/googletest
               ref: release-1.12.1
-      - name: Install solvers
+      - name: Install solvers via apt
+        if: matrix.solvers-from-source == 'OFF'
         uses: jrl-umi3218/github-actions/install-dependencies@master
         with:
           build-type: ${{ matrix.build-type }}
@@ -123,6 +125,35 @@ jobs:
               mc-rtc:
                 cloudsmith: mc-rtc/head
             apt: libmetis-dev libeigen3-dev libgtest-dev graphviz doxygen libeigen-qld-dev libeigen-quadprog-dev libjrl-qp-dev libqpoases-dev libosqp-eigen-dev libnasoq-dev libhpipm-dev libproxsuite-dev libqpmad-dev
+      - name: Install solvers from source
+        if: matrix.solvers-from-source == 'ON'
+        uses: jrl-umi3218/github-actions/install-dependencies@master
+        with:
+          build-type: ${{ matrix.build-type }}
+          ubuntu: |
+            apt: libmetis-dev libeigen3-dev libgtest-dev graphviz doxygen
+          github: |
+            - path: jrl-umi3218/eigen-qld
+              options: -DBUILD_TESTING=OFF -DPYTHON_BINDING=OFF -DINSTALL_DOCUMENTATION=OFF
+            - path: jrl-umi3218/eigen-quadprog
+              options: -DBUILD_TESTING=OFF -DINSTALL_DOCUMENTATION=OFF
+            - path: jrl-umi3218/jrl-qp
+              options: -DBUILD_TESTING=OFF -DBUILD_BENCHMARKS=OFF -DINSTALL_DOCUMENTATION=OFF
+            - path: coin-or/qpOASES
+              options: -DBUILD_SHARED_LIBS=ON -DQPOASES_BUILD_EXAMPLES=OFF
+            - path: osqp/osqp
+            - path: robotology/osqp-eigen
+            - path: mmurooka/nasoq
+              ref: cmake-install
+              options: -DCMAKE_INSTALL_PREFIX=/usr/local -DNASOQ_BLAS_BACKEND=OpenBLAS -DNASOQ_USE_CLAPACK=ON -DNASOQ_BUILD_CLI=OFF -DNASOQ_BUILD_EXAMPLES=OFF -DNASOQ_BUILD_TESTS=OFF -DNASOQ_BUILD_DOCS=OFF
+            - path: giaf/blasfeo
+              options: -DBUILD_SHARED_LIBS=ON -DTARGET=X64_AUTOMATIC -DBLASFEO_EXAMPLES=OFF
+            - path: giaf/hpipm
+              options: -DBUILD_SHARED_LIBS=ON -DHPIPM_TESTING=OFF
+            - path: Simple-Robotics/proxsuite
+              ref: main
+              options: -DBUILD_TESTING=OFF -DBUILD_WITH_VECTORIZATION_SUPPORT=OFF
+            - path: asherikov/qpmad
       - name: Install private solvers
         if: env.ENABLE_PRIVATE_SOLVERS == 'ON'
         uses: jrl-umi3218/github-actions/install-dependencies@master
@@ -162,7 +193,7 @@ jobs:
           options: -DDEFAULT_ENABLE_ALL=ON -DENABLE_LSSOL=${{ env.ENABLE_PRIVATE_SOLVERS }} -DSKIP_PRIVATE_SOLVER_TEST=${{ env.SKIP_PRIVATE_SOLVER_TEST }} -DFORCE_ALL_SOLVER_TEST=ON -DINSTALL_DOCUMENTATION=ON
       - name: Upload documentation
         # Only run for one configuration and on origin master branch
-        if: matrix.os == 'ubuntu-20.04' && matrix.build-type == 'RelWithDebInfo' && matrix.standalone == 'OFF' && github.repository_owner == 'isri-aist' && github.ref == 'refs/heads/master'
+        if: matrix.os == 'ubuntu-20.04' && matrix.build-type == 'RelWithDebInfo' && matrix.standalone == 'OFF' && matrix.solvers-from-source == 'OFF' && github.repository_owner == 'isri-aist' && github.ref == 'refs/heads/master'
         run: |
           set -e
           set -x


### PR DESCRIPTION
The solvers in apt do not track updates to each solver's origin repository. Continue to make sure that the build works with the latest source-installed solver. It is more complete to continue to make sure that the build works with solvers installed with the latest sources.

The step deleted in 7cb8b015e67ad25bd02ef5345aeafee5703dd463 is restored.